### PR TITLE
use clippy rules for no_std

### DIFF
--- a/runtime-rust/src/ast.rs
+++ b/runtime-rust/src/ast.rs
@@ -17,7 +17,7 @@
 
 //! Module for Abstract-Syntax Trees
 
-use alloc::fmt::{Display, Error, Formatter};
+use core::fmt::{Display, Error, Formatter};
 use core::iter::FusedIterator;
 
 use serde::ser::{Serialize, SerializeSeq, SerializeStruct, Serializer};

--- a/runtime-rust/src/errors.rs
+++ b/runtime-rust/src/errors.rs
@@ -17,7 +17,7 @@
 
 //! Module for the definition of lexical and syntactic errors
 
-use alloc::fmt::{Display, Formatter};
+use core::fmt::{Display, Formatter};
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -57,7 +57,7 @@ impl ParseErrorDataTrait for ParseErrorEndOfInput {
 }
 
 impl Display for ParseErrorEndOfInput {
-    fn fmt(&self, f: &mut Formatter<'_>) -> alloc::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "Unexpected end of input")
     }
 }
@@ -92,7 +92,7 @@ impl ParseErrorDataTrait for ParseErrorUnexpectedChar {
 }
 
 impl Display for ParseErrorUnexpectedChar {
-    fn fmt(&self, f: &mut Formatter<'_>) -> alloc::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "Unexpected character '{}' (U+{:X})",
@@ -138,7 +138,7 @@ impl ParseErrorDataTrait for ParseErrorIncorrectEncodingSequence {
 }
 
 impl Display for ParseErrorIncorrectEncodingSequence {
-    fn fmt(&self, f: &mut Formatter<'_>) -> alloc::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "Incorrect encoding sequence: [")?;
         if self.missing_high {
             write!(f, "<missing> 0x{:X}", self.sequence)?;
@@ -197,7 +197,7 @@ impl<'s> ParseErrorDataTrait for ParseErrorUnexpectedToken<'s> {
 }
 
 impl<'s> Display for ParseErrorUnexpectedToken<'s> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> alloc::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "Unexpected token \"{}\"", self.value)?;
         #[cfg(feature = "debug")]
         {
@@ -288,7 +288,7 @@ impl<'s> ParseErrorDataTrait for ParseError<'s> {
 }
 
 impl<'s> Display for ParseError<'s> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> alloc::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         // write!(f, "@{} ", self.get_position())?;
         match self {
             ParseError::UnexpectedEndOfInput(x) => x.fmt(f),

--- a/runtime-rust/src/lib.rs
+++ b/runtime-rust/src/lib.rs
@@ -40,6 +40,7 @@
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
 #![allow(clippy::cast_possible_truncation, clippy::module_name_repetitions)]
+#![warn(clippy::std_instead_of_core, clippy::std_instead_of_alloc, clippy::alloc_instead_of_core)]
 
 extern crate alloc;
 #[cfg(feature = "std")]

--- a/runtime-rust/src/sppf.rs
+++ b/runtime-rust/src/sppf.rs
@@ -640,13 +640,13 @@ impl SppfImplNode {
     pub fn add_version(&mut self, label: TableElemRef, children: &[SppfImplNodeRef]) -> usize {
         let result;
         (self.versions, result) =
-            std::mem::take(&mut self.versions).with_new_version(label, children);
+            core::mem::take(&mut self.versions).with_new_version(label, children);
         result
     }
 
     /// Adds new versions to this node
     pub fn add_versions(&mut self, versions: SppfImplNodeVersions<SppfImplNodeVersion>) {
-        self.versions = std::mem::take(&mut self.versions).with_new_versions(versions);
+        self.versions = core::mem::take(&mut self.versions).with_new_versions(versions);
     }
 
     /// Insert a series of children at the front
@@ -758,7 +758,7 @@ impl SppfImplNodeReplaceable {
     ) -> usize {
         let result;
         (self.versions, result) =
-            std::mem::take(&mut self.versions).with_new_version(label, children, actions);
+            core::mem::take(&mut self.versions).with_new_version(label, children, actions);
         result
     }
 

--- a/runtime-rust/src/symbols.rs
+++ b/runtime-rust/src/symbols.rs
@@ -17,7 +17,7 @@
 
 //! Module for the definition of grammar symbols
 
-use alloc::fmt::{Display, Error, Formatter};
+use core::fmt::{Display, Error, Formatter};
 
 use serde::{Deserialize, Serialize};
 

--- a/runtime-rust/src/text.rs
+++ b/runtime-rust/src/text.rs
@@ -18,7 +18,7 @@
 //! Module for text-handling APIs
 
 use alloc::borrow::Cow;
-use alloc::fmt::{Display, Error, Formatter};
+use core::fmt::{Display, Error, Formatter};
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::cmp::{Ord, Ordering};

--- a/runtime-rust/src/utils/biglist.rs
+++ b/runtime-rust/src/utils/biglist.rs
@@ -17,7 +17,7 @@
 
 //! Module for the definition of `BigList`
 
-use alloc::fmt::{self, Debug, Formatter};
+use core::fmt::{self, Debug, Formatter};
 use alloc::vec::Vec;
 use core::ops::{Index, IndexMut};
 


### PR DESCRIPTION
Run `cargo clippy --fix --allow-dirty --allow-staged -p hime_redist` to make sure `std` is out