### PR TITLE
WIP: Add SPPF Visitor

### DIFF
--- a/runtime-rust/Cargo.toml
+++ b/runtime-rust/Cargo.toml
@@ -19,6 +19,7 @@ debug = []
 std = ["serde/std"]
 
 [dependencies]
+dyn-clone = "1.0.14"
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 
 [badges]

--- a/runtime-rust/src/lib.rs
+++ b/runtime-rust/src/lib.rs
@@ -58,3 +58,5 @@ pub mod utils;
 
 /// The version of this program
 pub const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub use dyn_clone;

--- a/sdk-rust/src/output/lexer_rust.rs
+++ b/sdk-rust/src/output/lexer_rust.rs
@@ -98,7 +98,7 @@ pub fn write(
         if is_rnglr { ", ParseResultSppf" } else { "" }
     )?;
     if is_rnglr {
-        writeln!(writer, "use hime_redist::sppf::SppfImpl;")?;
+        writeln!(writer, "use hime_redist::sppf::{{SppfImpl, SppfNode, SppfNodeVersions}};")?;
     }
     writeln!(writer, "use hime_redist::symbols::SemanticBody;")?;
     writeln!(writer, "use hime_redist::symbols::SemanticElementTrait;")?;

--- a/sdk-rust/src/output/lexer_rust.rs
+++ b/sdk-rust/src/output/lexer_rust.rs
@@ -98,7 +98,9 @@ pub fn write(
         if is_rnglr { ", ParseResultSppf" } else { "" }
     )?;
     if is_rnglr {
-        writeln!(writer, "use hime_redist::sppf::{{SppfImpl, SppfNode, SppfNodeVersions}};")?;
+        writeln!(writer, "use hime_redist::sppf::{{SppfImpl, SppfNode, SppfNodeVersion}};")?;
+        writeln!(writer, "use hime_redist::dyn_clone::{{DynClone, clone_box}};")?;
+        writeln!(writer, "use alloc::boxed::Box;")?;
     }
     writeln!(writer, "use hime_redist::symbols::SemanticBody;")?;
     writeln!(writer, "use hime_redist::symbols::SemanticElementTrait;")?;

--- a/sdk-rust/src/output/parser_rust.rs
+++ b/sdk-rust/src/output/parser_rust.rs
@@ -622,14 +622,22 @@ fn write_code_sppf_visitor(
     )?;
     writeln!(
         writer,
-        "pub fn visit_sppf_node(node: SppfNode, visitor: Box<dyn SppfVisitor>) {{"
+        "pub fn visit_sppf_node(node: SppfNode, visitor: &Box<dyn SppfVisitor>) {{"
     )?;
-    writeln!(writer, "    let versions = node.versions();")?;
-    writeln!(writer, "    for version in versions {{")?;
-    writeln!(writer, "        let visitor = clone_box(&*visitor);")?;
-    writeln!(writer, "        visit_sppf_version_node(version, visitor);")?;
+
+    writeln!(writer, "      if node.versions_count() == 1 {{")?;
+    writeln!(writer, "            let version = node.first_version();")?;
+    writeln!(writer, "            visit_sppf_version_node(version, visitor);")?;
+    writeln!(writer, "      }} else {{")?;
+    writeln!(writer, "            let versions = node.versions();")?;
+    writeln!(writer, "            for version in versions {{")?;
+    writeln!(writer, "                let visitor = clone_box(&**visitor);")?;
+    writeln!(writer, "                visit_sppf_version_node(version, &visitor);")?;
+    writeln!(writer, "            }}")?;
+    writeln!(writer, "        }}")?;
     writeln!(writer, "    }}")?;
     writeln!(writer, "}}")?;
+    writeln!(writer)?;
 
     writeln!(
         writer,
@@ -637,7 +645,7 @@ fn write_code_sppf_visitor(
     )?;
     writeln!(
         writer,
-        "pub fn visit_sppf_version_node(node: SppfNodeVersion, visitor: Box<dyn SppfVisitor>) {{"
+        "pub fn visit_sppf_version_node(node: SppfNodeVersion, visitor: &Box<dyn SppfVisitor>) {{"
     )?;
     writeln!(writer, "    let children = node.children();")?;
     writeln!(writer, "    for child in children {{")?;

--- a/sdk-rust/src/output/parser_rust.rs
+++ b/sdk-rust/src/output/parser_rust.rs
@@ -608,7 +608,7 @@ fn write_code_sppf_visitor(
     writeln!(writer, "/// Walk the AST of a result using a visitor")?;
     writeln!(
         writer,
-        "pub fn visit_sppf(result: &ParseResult<SppfImpl>, visitor: Box<dyn SppfVisitor>) {{"
+        "pub fn visit_sppf(result: &ParseResult<SppfImpl>, visitor: &Box<dyn SppfVisitor>) {{"
     )?;
     writeln!(writer, "    let sppf = result.get_ast();")?;
     writeln!(writer, "    let root = sppf.get_root();")?;

--- a/sdk-rust/src/output/parser_rust.rs
+++ b/sdk-rust/src/output/parser_rust.rs
@@ -110,7 +110,8 @@ pub fn write(
             compress_automata,
         )?;
     }
-    write_code_visitor(&mut writer, grammar, expected)?;
+    write_code_ast_visitor(&mut writer, grammar, expected)?;
+    write_code_sppf_visitor(&mut writer, grammar, expected)?;
     Ok(())
 }
 
@@ -462,14 +463,14 @@ fn write_code_constructors(
 }
 
 /// Generates the visitor for the parse result
-fn write_code_visitor(
+fn write_code_ast_visitor(
     writer: &mut dyn Write,
     grammar: &Grammar,
     expected: &TerminalSet,
 ) -> Result<(), Error> {
     writeln!(writer)?;
-    writeln!(writer, "/// Visitor interface")?;
-    writeln!(writer, "pub trait Visitor {{")?;
+    writeln!(writer, "/// AST Visitor interface")?;
+    writeln!(writer, "pub trait AstVisitor {{")?;
     for terminal_ref in &expected.content {
         let Some(terminal) = grammar.get_terminal(terminal_ref.sid()) else {
             continue;
@@ -505,7 +506,7 @@ fn write_code_visitor(
     writeln!(writer, "/// Walk the AST of a result using a visitor")?;
     writeln!(
         writer,
-        "pub fn visit(result: &ParseResult<AstImpl>, visitor: &dyn Visitor) {{"
+        "pub fn visit(result: &ParseResult<AstImpl>, visitor: &dyn AstVisitor) {{"
     )?;
     writeln!(writer, "    let ast = result.get_ast();")?;
     writeln!(writer, "    let root = ast.get_root();")?;
@@ -518,11 +519,128 @@ fn write_code_visitor(
     )?;
     writeln!(
         writer,
-        "pub fn visit_ast_node(node: AstNode, visitor: &dyn Visitor) {{"
+        "pub fn visit_ast_node(node: AstNode, visitor: &dyn AstVisitor) {{"
     )?;
     writeln!(writer, "    let children = node.children();")?;
     writeln!(writer, "    for child in children.iter() {{")?;
     writeln!(writer, "        visit_ast_node(child, visitor);")?;
+    writeln!(writer, "    }}")?;
+    writeln!(writer, "    match node.get_symbol().id {{")?;
+    for terminal_ref in &expected.content {
+        let Some(terminal) = grammar.get_terminal(terminal_ref.sid()) else {
+            continue;
+        };
+        if terminal.name.starts_with(PREFIX_GENERATED_TERMINAL) {
+            continue;
+        }
+        writeln!(
+            writer,
+            "        0x{:04X} => visitor.on_terminal_{}(&node),",
+            terminal.id,
+            to_snake_case(&terminal.name)
+        )?;
+    }
+    for variable in &grammar.variables {
+        if variable.name.starts_with(PREFIX_GENERATED_VARIABLE) {
+            continue;
+        }
+        writeln!(
+            writer,
+            "        0x{:04X} => visitor.on_variable_{}(&node),",
+            variable.id,
+            to_snake_case(&variable.name)
+        )?;
+    }
+    for symbol in &grammar.virtuals {
+        writeln!(
+            writer,
+            "        0x{:04X} => visitor.on_virtual_{}(&node),",
+            symbol.id,
+            to_snake_case(&symbol.name)
+        )?;
+    }
+    writeln!(writer, "        _ => ()")?;
+    writeln!(writer, "    }};")?;
+    writeln!(writer, "}}")?;
+    Ok(())
+}
+
+fn write_code_sppf_visitor(
+    writer: &mut dyn Write,
+    grammar: &Grammar,
+    expected: &TerminalSet,
+) -> Result<(), Error> {
+    writeln!(writer)?;
+    writeln!(writer, "/// SPPF Visitor interface")?;
+    writeln!(writer, "pub trait SppfVisitor {{")?;
+    for terminal_ref in &expected.content {
+        let Some(terminal) = grammar.get_terminal(terminal_ref.sid()) else {
+            continue;
+        };
+        if terminal.name.starts_with(PREFIX_GENERATED_TERMINAL) {
+            continue;
+        }
+        writeln!(
+            writer,
+            "    fn on_terminal_{}(&self, _node: &SppfNodeVersions) {{}}",
+            to_snake_case(&terminal.name)
+        )?;
+    }
+    for variable in &grammar.variables {
+        if variable.name.starts_with(PREFIX_GENERATED_VARIABLE) {
+            continue;
+        }
+        writeln!(
+            writer,
+            "    fn on_variable_{}(&self, _node: &SppfNodeVersions) {{}}",
+            to_snake_case(&variable.name)
+        )?;
+    }
+    for symbol in &grammar.virtuals {
+        writeln!(
+            writer,
+            "    fn on_virtual_{}(&self, _node: &SppfNodeVersions) {{}}",
+            to_snake_case(&symbol.name)
+        )?;
+    }
+    writeln!(writer, "}}")?;
+    writeln!(writer)?;
+    writeln!(writer, "/// Walk the AST of a result using a visitor")?;
+    writeln!(
+        writer,
+        "pub fn visit(result: &ParseResult<AstImpl>, visitor: &dyn SppfVisitor) {{"
+    )?;
+    writeln!(writer, "    let sppf = result.get_ast();")?;
+    writeln!(writer, "    let root = sppf.get_root();")?;
+    writeln!(writer, "    visit_sppf_node(root, visitor);")?;
+    writeln!(writer, "}}")?;
+    writeln!(writer)?;
+
+    writeln!(
+        writer,
+        "/// Walk the sub-AST from the specified node using a visitor"
+    )?;
+    writeln!(
+        writer,
+        "pub fn visit_sppf_node(node: SppfNode, visitor: &dyn SppfVisitor) {{"
+    )?;
+    writeln!(writer, "    let versions = node.versions();")?;
+    writeln!(writer, "    for version in versions.iter() {{")?;
+    writeln!(writer, "        visit_sppf_version_node(version, visitor);")?;
+    writeln!(writer, "    }}")?;
+    writeln!(writer, "}}")?;
+
+    writeln!(
+        writer,
+        "/// Walk the sub-AST from the specified node using a visitor"
+    )?;
+    writeln!(
+        writer,
+        "pub fn visit_sppf_version_node(node: SppfNode, visitor: &dyn SppfVisitor) {{"
+    )?;
+    writeln!(writer, "    let children = node.children();")?;
+    writeln!(writer, "    for child in children.iter() {{")?;
+    writeln!(writer, "        visit_sppf_node(child, visitor);")?;
     writeln!(writer, "    }}")?;
     writeln!(writer, "    match node.get_symbol().id {{")?;
     for terminal_ref in &expected.content {

--- a/sdk-rust/src/output/parser_rust.rs
+++ b/sdk-rust/src/output/parser_rust.rs
@@ -506,7 +506,7 @@ fn write_code_ast_visitor(
     writeln!(writer, "/// Walk the AST of a result using a visitor")?;
     writeln!(
         writer,
-        "pub fn visit(result: &ParseResult<AstImpl>, visitor: &dyn AstVisitor) {{"
+        "pub fn visit_ast(result: &ParseResult<AstImpl>, visitor: &dyn AstVisitor) {{"
     )?;
     writeln!(writer, "    let ast = result.get_ast();")?;
     writeln!(writer, "    let root = ast.get_root();")?;
@@ -608,7 +608,7 @@ fn write_code_sppf_visitor(
     writeln!(writer, "/// Walk the AST of a result using a visitor")?;
     writeln!(
         writer,
-        "pub fn visit(result: &ParseResult<AstImpl>, visitor: &dyn SppfVisitor) {{"
+        "pub fn visit_sppf(result: &ParseResult<AstImpl>, visitor: &dyn SppfVisitor) {{"
     )?;
     writeln!(writer, "    let sppf = result.get_ast();")?;
     writeln!(writer, "    let root = sppf.get_root();")?;

--- a/sdk-rust/src/output/parser_rust.rs
+++ b/sdk-rust/src/output/parser_rust.rs
@@ -572,7 +572,7 @@ fn write_code_sppf_visitor(
 ) -> Result<(), Error> {
     writeln!(writer)?;
     writeln!(writer, "/// SPPF Visitor interface")?;
-    writeln!(writer, "pub trait SppfVisitor {{")?;
+    writeln!(writer, "pub trait SppfVisitor: DynClone {{")?;
     for terminal_ref in &expected.content {
         let Some(terminal) = grammar.get_terminal(terminal_ref.sid()) else {
             continue;
@@ -582,7 +582,7 @@ fn write_code_sppf_visitor(
         }
         writeln!(
             writer,
-            "    fn on_terminal_{}(&self, _node: &SppfNodeVersions) {{}}",
+            "    fn on_terminal_{}(&self, _node: &SppfNodeVersion) {{}}",
             to_snake_case(&terminal.name)
         )?;
     }
@@ -592,14 +592,14 @@ fn write_code_sppf_visitor(
         }
         writeln!(
             writer,
-            "    fn on_variable_{}(&self, _node: &SppfNodeVersions) {{}}",
+            "    fn on_variable_{}(&self, _node: &SppfNodeVersion) {{}}",
             to_snake_case(&variable.name)
         )?;
     }
     for symbol in &grammar.virtuals {
         writeln!(
             writer,
-            "    fn on_virtual_{}(&self, _node: &SppfNodeVersions) {{}}",
+            "    fn on_virtual_{}(&self, _node: &SppfNodeVersion) {{}}",
             to_snake_case(&symbol.name)
         )?;
     }
@@ -608,7 +608,7 @@ fn write_code_sppf_visitor(
     writeln!(writer, "/// Walk the AST of a result using a visitor")?;
     writeln!(
         writer,
-        "pub fn visit_sppf(result: &ParseResult<AstImpl>, visitor: &dyn SppfVisitor) {{"
+        "pub fn visit_sppf(result: &ParseResult<SppfImpl>, visitor: Box<dyn SppfVisitor>) {{"
     )?;
     writeln!(writer, "    let sppf = result.get_ast();")?;
     writeln!(writer, "    let root = sppf.get_root();")?;
@@ -622,10 +622,11 @@ fn write_code_sppf_visitor(
     )?;
     writeln!(
         writer,
-        "pub fn visit_sppf_node(node: SppfNode, visitor: &dyn SppfVisitor) {{"
+        "pub fn visit_sppf_node(node: SppfNode, visitor: Box<dyn SppfVisitor>) {{"
     )?;
     writeln!(writer, "    let versions = node.versions();")?;
-    writeln!(writer, "    for version in versions.iter() {{")?;
+    writeln!(writer, "    for version in versions {{")?;
+    writeln!(writer, "        let visitor = clone_box(&*visitor);")?;
     writeln!(writer, "        visit_sppf_version_node(version, visitor);")?;
     writeln!(writer, "    }}")?;
     writeln!(writer, "}}")?;
@@ -636,10 +637,10 @@ fn write_code_sppf_visitor(
     )?;
     writeln!(
         writer,
-        "pub fn visit_sppf_version_node(node: SppfNode, visitor: &dyn SppfVisitor) {{"
+        "pub fn visit_sppf_version_node(node: SppfNodeVersion, visitor: Box<dyn SppfVisitor>) {{"
     )?;
     writeln!(writer, "    let children = node.children();")?;
-    writeln!(writer, "    for child in children.iter() {{")?;
+    writeln!(writer, "    for child in children {{")?;
     writeln!(writer, "        visit_sppf_node(child, visitor);")?;
     writeln!(writer, "    }}")?;
     writeln!(writer, "    match node.get_symbol().id {{")?;

--- a/sdk-rust/src/output/parser_rust.rs
+++ b/sdk-rust/src/output/parser_rust.rs
@@ -625,15 +625,14 @@ fn write_code_sppf_visitor(
         "pub fn visit_sppf_node(node: SppfNode, visitor: &Box<dyn SppfVisitor>) {{"
     )?;
 
-    writeln!(writer, "      if node.versions_count() == 1 {{")?;
-    writeln!(writer, "            let version = node.first_version();")?;
-    writeln!(writer, "            visit_sppf_version_node(version, visitor);")?;
-    writeln!(writer, "      }} else {{")?;
-    writeln!(writer, "            let versions = node.versions();")?;
-    writeln!(writer, "            for version in versions {{")?;
-    writeln!(writer, "                let visitor = clone_box(&**visitor);")?;
-    writeln!(writer, "                visit_sppf_version_node(version, &visitor);")?;
-    writeln!(writer, "            }}")?;
+    writeln!(writer, "    if node.versions_count() == 1 {{")?;
+    writeln!(writer, "        let version = node.first_version();")?;
+    writeln!(writer, "        visit_sppf_version_node(version, visitor);")?;
+    writeln!(writer, "    }} else {{")?;
+    writeln!(writer, "        let versions = node.versions();")?;
+    writeln!(writer, "        for version in versions {{")?;
+    writeln!(writer, "            let visitor = clone_box(&**visitor);")?;
+    writeln!(writer, "            visit_sppf_version_node(version, &visitor);")?;
     writeln!(writer, "        }}")?;
     writeln!(writer, "    }}")?;
     writeln!(writer, "}}")?;


### PR DESCRIPTION
This PR implements part of the idea expressed here: [https://github.com/cenotelie/hime/issues/88#issuecomment-1761391207](https://github.com/cenotelie/hime/issues/88#issuecomment-1761391207)

> I have another obscure idea I can't express clearly (I'm not sure if that's novel or not) that if we want to implement semantic checker to multiple "trees"/"branches" of the SPPF at the same time, at the very least, the data structure state holding the information about the current AST walker must be immutable -- which means data is cloned between each forest transition. Then we will need to use persistent data structure/Copy-On-Write mechanism/transactional memory to manage the state data. While I'm pretty sure functional programming people may have enjoyed writing parsers this way because their way to handle data structures are immutable by design, so this is trivial for all kinds of program, but this idea came back to the time when I was still using rust-peg ([kevinmehall/rust-peg#301](https://github.com/kevinmehall/rust-peg/discussions/301))

TODO:

1.  Figure out how to emit the divergent visitors on different versions
    1.  This can be done using a vector, but I think iterator would be okay too