### PR TITLE
fixed issue 109: In memory grammar

### DIFF
--- a/sdk-rust/src/output/mod.rs
+++ b/sdk-rust/src/output/mod.rs
@@ -253,7 +253,7 @@ pub fn build_in_memory_grammar<'a>(
         return Err(vec![error]);
     }
     let mut parser_automaton = Vec::new();
-    if let Err(error) = if data.method.is_rnglr() {
+    if let Err(error) = if !data.method.is_rnglr() {
         parser_data::write_parser_lrk_data(
             &mut parser_automaton,
             grammar,

--- a/sdk-rust/src/sdk.rs
+++ b/sdk-rust/src/sdk.rs
@@ -110,7 +110,7 @@ impl<'s> InMemoryParser<'s> {
         repository: TokenRepository<'s, 't, 'a>,
         errors: &'a mut ParseErrors<'s>,
     ) -> Lexer<'s, 't, 'a> {
-        if self.lexer_is_context_sensitive {
+        if !self.lexer_is_context_sensitive {
             Lexer::ContextFree(ContextFreeLexer::new(
                 repository,
                 errors,

--- a/sdk-rust/tests/regressions.rs
+++ b/sdk-rust/tests/regressions.rs
@@ -1,4 +1,6 @@
-use hime_sdk::output::helper::{get_namespace_java, get_namespace_net, get_namespace_rust};
+use std::borrow::BorrowMut;
+
+use hime_sdk::{output::helper::{get_namespace_java, get_namespace_net, get_namespace_rust}, ParsingMethod};
 
 /// [Github issue #79](https://github.com/cenotelie/hime/issues/79)
 #[test]
@@ -9,4 +11,44 @@ fn test_namespace_transformation() {
     assert_eq!(get_namespace_net("a::b::c"), String::from("A.B.C"));
     assert_eq!(get_namespace_rust("a.b.c"), String::from("a::b::c"));
     assert_eq!(get_namespace_rust("a::b::c"), String::from("a::b::c"));
+}
+
+/// [Github issue #109](https://github.com/cenotelie/hime/issues/109)
+#[test]
+pub fn test_in_memory_parser(){
+    let text_grammar = r#"
+    grammar Test
+    {
+        options
+        {
+            Axiom = "expression";
+        }
+        terminals
+        {
+            A -> 'a'+;
+        }
+        rules
+        {
+            expression -> A ;
+        }
+    }
+    "#;
+
+    let input = hime_sdk::Input::Raw(&text_grammar);
+    let inputs = vec![input];
+    if let Ok(l) = hime_sdk::loaders::load_inputs(&inputs) {
+        // The load_inputs allows to load multiple inputs and turn them into grammars,
+        // but in our case, we only have one input grammar
+        let mut grammars = l.grammars;            
+        let input_grammar = grammars[0].borrow_mut();
+        if let Ok(data) = input_grammar.build(Some(ParsingMethod::LR1), 0) {
+            if let Ok(parser) = hime_sdk::output::build_in_memory_grammar(input_grammar, &data) {
+                let res_1 = parser.parse("aaa");
+                assert!(res_1.is_success()); 
+                let res_2 = parser.parse("aaab");
+                assert!(!res_2.is_success()); 
+            }
+        }   
+    }
+    
 }


### PR DESCRIPTION
Referring to issue 109: https://github.com/cenotelie/hime/issues/109 and also other related issues such as 104: https://github.com/cenotelie/hime/issues/104.

The problem is with the in memory parser in which: (1) the function build_in_memory_grammar incorrectly initializes/writes the parser with lrk when the option is_rnglr is True. (2) the SDK incorrectly initializes the lexer as ContextFree when the option lexer_is_context_sensitive is True.

Therefore, the fix is to negate the conditions if the if conditions so that the lexer and the parser are created with the right kinds, e.g., LRK parser and ContextFree lexer. 

A test case is attached for this bug fix.